### PR TITLE
Bug report

### DIFF
--- a/gmail.js
+++ b/gmail.js
@@ -19,4 +19,4 @@ function main() {
 
     thread.removeLabel(label);
   });
-}
+}x


### PR DESCRIPTION
Just a couple of fixes for the script:

Messages aren't found if already in spam "folder".
The hyperlink formula is incorrect when using some locales (`;` instead of `,` as formula separator.)

```js
function doGmail() {
    // ...
    var threads = GmailApp.search(`label:${label} in:all`);
    // ...
    var hyperlink = '=HYPERLINK("#LINK#"; "View")';
   // ; is universal apparently and will be converted when needed https://stackoverflow.com/a/61283851/2124535
```